### PR TITLE
Add :with_root option

### DIFF
--- a/lib/cast_decorator.ex
+++ b/lib/cast_decorator.ex
@@ -18,7 +18,8 @@ defmodule ConstructParams.CastDecorator do
       end
   """
 
-  use Decorator.Define, cast: 2
+  use Decorator.Define, [cast: 2, cast: 1]
+  def cast(cast_module, body, context), do: cast(cast_module, [], body, context)
 
   def cast(cast_module, options, body, %{args: [conn, params], module: module}) do
     fallback_module = get_fallback_module(module)

--- a/lib/cast_decorator.ex
+++ b/lib/cast_decorator.ex
@@ -18,18 +18,38 @@ defmodule ConstructParams.CastDecorator do
       end
   """
 
-  use Decorator.Define, cast: 1
+  use Decorator.Define, cast: 2
 
-  def cast(cast_module, body, %{args: [conn, params], module: module}) do
+  def cast(cast_module, options, body, %{args: [conn, params], module: module}) do
     fallback_module = get_fallback_module(module)
 
     quote do
-      case unquote(cast_module).make(unquote(params), make_map: true) do
+      origin_params =
+        if Keyword.get(unquote(options), :with_root, false) do
+          %{"root" => unquote(params)}
+        else
+          unquote(params)
+        end
+
+      case unquote(cast_module).make(origin_params, make_map: true) do
         {:ok, casted_params} ->
-          unquote(params) = casted_params
+          unquote(params) =
+            if Keyword.get(unquote(options), :with_root, false) do
+              casted_params[:root]
+            else
+              casted_params
+            end
+
           unquote(body)
 
         {:error, errors} ->
+          errors =
+            if Keyword.get(unquote(options), :with_root, false) do
+              errors[:root]
+            else
+              errors
+            end
+
           unquote(fallback_module).call(unquote(conn), {:error, :invalid_params, errors})
       end
     end


### PR DESCRIPTION
In some cases, when there are several valid params sets and one API for processing it, you need to validate each case separately, since there is no way to optionally set validation conditions the parameters should be wrapped under the root key to be able to apply the specific validation structure

Example:
We have two different valid sets of params and one API endpoint for processing them.

Possible params
`%{"login" => "some", "password" => "12345678"}`

> or

`%{"email" => "some", "password" => "12345678"}`

We cannot use one structure to validate two different sets of parameters.
For this, there must be a root parameter with a custom type, which will allow validating the parameters depending on the conditions.

**Define the validation module**

```elixir
defmodule MyAppWeb.Api.Requests.Users.Index do
  defmodule UserLogin do
    use Construct do
      field(:login, :string)
      field(:password, :string)
    end
  end

  defmodule UserEmail do
    use Construct do
      field(:email, :string)
      field(:password, :string)
    end
  end

  defmodule UserParams do
    @behaviour Construct.Type

    def cast(%{"login" => _} = v), do: UserLogin.make(v, make_map: true)
    def cast(%{"email" => _} = v), do: UserEmail.make(v, make_map: true)

    def cast(_), do: :error
  end

  use Construct do
    field(:root, UserParams)
  end
end
```

**Use this module with** `with_root: true`

```elixir
defmodule MyAppWeb.Api.UsersController do
  use ConstructParams.CastDecorator

  @decorate cast(MyAppWeb.Api.Requests.Users.Index, with_root: true)
  def index(conn, params) do
  end
end
```

`root` parameter is needed only to apply the right validation and it will be removed after validation is finished
